### PR TITLE
Mythic keystone search hack

### DIFF
--- a/LibItemCache-2.0.lua
+++ b/LibItemCache-2.0.lua
@@ -254,6 +254,12 @@ function Lib:IsBagCached(realm, name, isguild, bag)
 end
 
 function Lib:RestoreItemData(item)
+	
+	--Clear the link so we only use the id for mythic keystones
+	if (item.id == 158923) then
+		item.link = nil;
+	end
+	
 	local link, id, quality, icon = self:RestoreLinkData(item.link or item.id)
 	local query = link or item.id or id
 


### PR DESCRIPTION
I'm sure there are much better solutions, but this would resolve the inability to search for the keystone without affecting any other items.